### PR TITLE
fix: remove `currentSession` decorator dependency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -248,9 +248,6 @@ export default fp(fastifyAuth0LoginPlugin, {
   dependencies: [
     '@fastify/cookie',
   ],
-  decorators: {
-    request: ['currentSession'],
-  },
 });
 
 declare module 'fastify' {


### PR DESCRIPTION
Fix this issue:

```
FastifyError [Error]: The decorator 'currentSession' required by 'fastify-auth0-login' is not present in Request
```
